### PR TITLE
refactor(uuid): 重构Uuid生成实现

### DIFF
--- a/PCL.Neo.Core/PCL.Neo.Core.csproj
+++ b/PCL.Neo.Core/PCL.Neo.Core.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -15,13 +16,9 @@
         <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
     </ItemGroup>
 
-
-    <ItemGroup>
-      <Folder Include="Utils\" />
-    </ItemGroup>
-
     <ItemGroup>
       <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+      <PackageReference Include="Uuids" Version="2.0.0" />
     </ItemGroup>
 
 </Project>

--- a/PCL.Neo.Core/Utils/Uuid.cs
+++ b/PCL.Neo.Core/Utils/Uuid.cs
@@ -1,18 +1,63 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace PCL.Neo.Core.Utils;
 
 public static partial class Uuid // TODO: implement different way of genereate uuid
 {
-    private const string DefaultUuid = "00000000-0000-0000-0000-000000000000";
-
-    public static string GenerateOfflineUuid(string username)
+    public enum UuidGenerateType
     {
-        if (string.IsNullOrEmpty(username) || !IsValidUsername(username))
-            return DefaultUuid;
-        var guid = new Guid(MurmurHash3.Hash(username));
-        return guid.ToString();
+        Guid,
+        Standard,
+        MurmurHash3
     }
+
+    /// <summary>
+    /// Generate UUID base on input username. If username is empty or invalid,
+    /// throw <see cref="ArgumentException"/>.
+    /// </summary>
+    /// <param name="username">Username to generate UUID.</param>
+    /// <param name="type">Type of UUID generation.</param>
+    /// <returns>Generated UUID.</returns>
+    /// <exception cref="ArgumentException">
+    /// If <paramref name="username"/> is invalid or empty.
+    /// </exception>
+    public static string GenerateUuid(string username, UuidGenerateType type)
+    {
+        if (string.IsNullOrEmpty(username) ||
+            !IsValidUsername(username))
+        {
+            throw new ArgumentException("Username is invalid.");
+        }
+
+        var fullName = $"OfflinePlayer:{username}";
+
+        var uuid = type switch
+        {
+            UuidGenerateType.Guid => new Guid(MD5.HashData(Encoding.UTF8.GetBytes(fullName))).ToString(),
+            UuidGenerateType.Standard => StadardVer(fullName),
+            UuidGenerateType.MurmurHash3 => new Guid(MurmurHash3.Hash(fullName)).ToString(),
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+
+        uuid = uuid.Replace("-", string.Empty);
+
+        return uuid;
+    }
+
+    private static string StadardVer(string name)
+    {
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(name));
+
+        hash[6] = (byte)((hash[6] & 0x0F) | 0x30); // Version 3
+        hash[8] = (byte)((hash[8] & 0x3F) | 0x80); // Variant 1 (RFC 4122)
+
+        return new Uuids.Uuid(hash).ToString();
+    }
+
+    [GeneratedRegex("^[a-zA-Z0-9_]+$")]
+    private static partial Regex ValidUsernameRegex();
 
     public static bool IsValidUsername(string username)
     {
@@ -22,11 +67,12 @@ public static partial class Uuid // TODO: implement different way of genereate u
     }
 
     // MurmurHash3算法实现
+
     private static class MurmurHash3
     {
         public static byte[] Hash(string str)
         {
-            var bytes = System.Text.Encoding.UTF8.GetBytes(str);
+            var bytes = Encoding.UTF8.GetBytes(str);
             const uint seed = 144;
             const uint c1 = 0xcc9e2d51;
             const uint c2 = 0x1b873593;
@@ -80,7 +126,4 @@ public static partial class Uuid // TODO: implement different way of genereate u
             return h;
         }
     }
-
-    [GeneratedRegex("^[a-zA-Z0-9_]+$")]
-    private static partial Regex ValidUsernameRegex();
 }

--- a/PCL.Neo.Tests/Utils/UuidTest.cs
+++ b/PCL.Neo.Tests/Utils/UuidTest.cs
@@ -1,0 +1,23 @@
+using PCL.Neo.Core.Utils;
+using System;
+
+namespace PCL.Neo.Tests.Utils
+{
+    [TestFixture]
+    [TestOf(typeof(Uuid))]
+    public class UuidTest
+    {
+        [Test]
+        public void UuidGenerateTest()
+        {
+            var name = "WhiteCat";
+            var uuid1 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.Guid);
+            var uuid2 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.Standard);
+            var uuid3 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.MurmurHash3);
+
+            Console.WriteLine(uuid1);
+            Console.WriteLine(uuid2);
+            Console.WriteLine(uuid3);
+        }
+    }
+}


### PR DESCRIPTION
# 概述
这个PR重构了UUID的生成方式，保留了原来的生成方式的同时新增了另外两种生成方式（微软的Guid方式和启动器标准生成方式）

# 引入的包
- [Uuids](https://www.nuget.org/packages/Uuids/2.0.0)：用于提供启动器标准生成方式

# 修改部分
- 删除`DefauleUuid`属性
- 新增`UuidGenarateType`用于控制Uuid生成方式
- 新增`Standard`和`Guid`两种生成方式类型
- 将原当当玩家名称不合法时返回`DefaultUuid`改为抛出`ArgumentException`

# 使用
```csharp
var name = "WhiteCat";
var uuid1 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.Guid);
var uuid2 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.Standard);
var uuid3 = Uuid.GenerateUuid(name, Uuid.UuidGenerateType.MurmurHash3);
```
一看便知，应该不需要我说了……

# 输出
输出格式为无'-'符合的输出格式，用于兼容游戏启动参数，如：
```
f378a5e208f03069a6db90e86d23f09a
```